### PR TITLE
Makefile updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-coverage.html
-coverage.out
 overcover
+coverage.out
+coverage.html
+.gitignore.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
 - "1.13.x"
+- "1.14.x"
 install:
 - go get -u -v golang.org/x/tools/cmd/goimports
 - go get -u -v golang.org/x/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ install:
 - go get -u -v github.com/mattn/goveralls
 script:
 - make CI=true
-- make cover-test CI=true
 - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -15,30 +15,51 @@
 # Packages to test; can be overridden at the command line
 PACKAGES    = ./...
 
-PKG_ROOT    = $(shell grep '^module ' go.mod | awk '{print $$NF}')
+# File for repository ignores
+IGNORE      = .gitignore
 
+# Get the module root and name
+PKG_ROOT    = $(shell grep '^module ' go.mod | awk '{print $$NF}')
+PKG_NAME    = $(notdir $(PKG_ROOT))
+
+# Names of the various commands
 GO          = go
 GOFMT       = gofmt
 GOIMPORTS   = goimports
 GOLINT      = golint
-OVERCOVER   = ./overcover
+OVERCOVER   = overcover
 
+# Coverage configuration file
 COV_CONF    = .overcover.yaml
 
-SOURCES     = $(shell find . -name \*.go -print)
+# Additional arguments to pass to overcover
+COVER_ARGS  = --summary
 
-TEST_DATA   = $(shell find . -path '*/testdata/*' -type f -print)
-
-_mainPkgRE  = ^\s*package\s\s*main\s*\(\#.*\)*$$
-_mainFuncRE = ^\s*func\s\s*main(.*$$
-BINSRC      = $(shell echo "$(SOURCES)" | xargs grep -H '$(_mainPkgRE)' | awk -F: '{print $$1}' | sort -u | xargs grep -H '$(_mainFuncRE)' | awk -F: '{print $$1}' | sort -u)
-BINS        = $(patsubst %.go,%,$(BINSRC))
-
+# Coverage data and report files
 COVER_OUT   = coverage.out
 COVER_HTML  = coverage.html
 
-CLEAN       = $(BINS) $(COVER_OUT) $(COVER_HTML)
+# Collect the sources and test data files for dependencies
+SOURCES     = $(shell find . -name \*.go -print)
+TEST_DATA   = $(shell find . -path '*/testdata/*' -type f -print)
 
+# Macro to convert a source file name to the corresponding expected
+# binary name.
+BINNAME     = $(patsubst .,$(PKG_NAME),$(notdir $(patsubst %/,%,$(dir $(1)))))
+
+# Identify the binaries to build; searches for source files that are
+# "package main" that contain a "main" function.  Binary names will be
+# drawn from the directory the files are in.
+_mainPkgRE  = ^\s*package\s\s*main\s*\(\#.*\)*$$
+_mainFuncRE = ^\s*func\s\s*main(.*$$
+BINSRC      = $(shell echo "$(SOURCES)" | xargs grep -H '$(_mainPkgRE)' | awk -F: '{print $$1}' | sort -u | xargs grep -H '$(_mainFuncRE)' | awk -F: '{print $$1}' | sort -u)
+BINS        = $(call BINNAME,$(BINSRC))
+
+# Files to be cleaned up on "make clean"
+CLEAN       = $(BINS) $(COVER_OUT) $(COVER_HTML) $(IGNORE).tmp
+
+# CI-linked variables; these set up read-only behavior within a CI
+# system
 ifeq ($(CI),true)
 FORMAT_TARG = format-test
 MOD_ARG     = -mod=readonly
@@ -49,11 +70,23 @@ MOD_ARG     =
 COV_ARG     =
 endif
 
-all: test build
+# Compute the dependencies for the "all" target
+ALL_TARG    = $(IGNORE) test
+ifneq ($(BINS),)
+ALL_TARG    += build
+endif
 
-build: $(BINS)
+# Set up dependencies for the "test" and "cover" targets
+TEST_TARG   = $(FORMAT_TARG) lint vet test-only
 
-format-test:
+all: $(ALL_TARG) ## Run tests and build binaries (if any)
+
+build: $(BINS) ## Build binaries (if any)
+
+tidy: ## Ensure go.mod matches the source code
+	$(GO) mod tidy
+
+format-test: ## Check that source files are properly formatted
 	@all=`( \
 		$(GOIMPORTS) -l -local $(PKG_ROOT) $(SOURCES); \
 		$(GOFMT) -l -s $(SOURCES) \
@@ -67,36 +100,91 @@ format-test:
 		exit 1; \
 	fi
 
-format:
+format: ## Format source files properly
 	$(GOIMPORTS) -l -local $(PKG_ROOT) -w $(SOURCES)
 	$(GOFMT) -l -s -w $(SOURCES)
 
-lint:
+lint: ## Lint-check source files
 	$(GOLINT) -set_exit_status $(PACKAGES)
 
-vet:
-	$(GO) vet $(PACKAGES)
+vet: ## Vet source files
+	$(GO) vet $(MOD_ARG) $(PACKAGES)
 
-test-only:
+test-only: ## Run tests only
 	$(GO) test $(MOD_ARG) -race -coverprofile=$(COVER_OUT) $(PACKAGES)
 
-test: $(FORMAT_TARG) lint vet test-only
+test: $(TEST_TARG) cover-test ## Run all tests
 
-cover-test: $(COVER_OUT) $(OVERCOVER)
-	$(OVERCOVER) --config $(COV_CONF) $(COV_ARG) --coverprofile $(COVER_OUT)
+cover: $(TEST_TARG) $(COVER_HTML) cover-test ## Run tests and generate a coverage report
 
-cover: $(COVER_HTML)
+cover-test: $(COVER_OUT) ## Test that coverage meets minimum configured threshold
+	$(OVERCOVER) --config $(COV_CONF) $(COV_ARG) --coverprofile $(COVER_OUT) $(COVER_ARGS) $(PACKAGES)
 
 $(COVER_OUT): $(SOURCES) $(TEST_DATA)
-	$(MAKE) test
+	$(MAKE) test-only
 
 $(COVER_HTML): $(COVER_OUT)
 	$(GO) tool cover -html=$(COVER_OUT) -o $(COVER_HTML)
 
-clean:
+clean: ## Clean up intermediate files
 	rm -f $(CLEAN)
 
+# Sets up build targets for each binary
+ifneq ($(BINS),)
 $(BINS): $(SOURCES)
 
-%: %.go
-	$(GO) build -o $@ $<
+define BIN_template =
+$$(call BINNAME,$(1)):
+	$(GO) build $(MOD_ARG) -o $$(call BINNAME,$(1)) $(1)
+endef
+
+$(foreach bin,$(BINSRC),$(eval $(call BIN_template,$(bin))))
+endif
+
+$(IGNORE).tmp:
+	echo $(CLEAN) | sed 's/ /\n/g' > $(IGNORE).tmp
+
+$(IGNORE): $(IGNORE).tmp
+ifeq ($(CI),true)
+	@if cmp $(IGNORE) $(IGNORE).tmp >/dev/null 2>&1; then \
+		:; \
+	else \
+		echo "The $(IGNORE) file requires regeneration."; \
+		echo "Use \"make $(IGNORE)\" to regenerate it."; \
+		echo "Current contents:"; \
+		echo; \
+		cat $(IGNORE); \
+		echo; \
+		echo "Expected contents:"; \
+		echo; \
+		cat $(IGNORE).tmp; \
+		exit 1; \
+	fi
+else
+	mv $(IGNORE).tmp $(IGNORE)
+endif
+
+include scripts/*.mk
+
+help: ## Emit help for the Makefile
+	@echo "Available make targets:"
+	@echo
+	@grep -h '^[^ 	:].*:.*##' $(MAKEFILE_LIST) | sed 's/:.*## */:/g' | \
+		sort -u | awk -F: '{ \
+			if (length($$1) > width) { \
+				width = length($$1); \
+			} \
+			targets[targetCnt++] = $$1; \
+			help[$$1] = $$2; \
+		} \
+		END { \
+			indent = sprintf("\n  %*s  ", width, ""); \
+			for (i = 0; i < targetCnt; i++) { \
+				target = targets[i]; \
+				helpText = help[target]; \
+				gsub("\\\\n", indent, helpText); \
+				printf("  %-*s  %s\n", width, target, helpText); \
+			} \
+		}'
+
+.PHONY: all build tidy format-test format lint vet test-only test cover-test cover clean help

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -12,9 +13,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/klmitch/patcher v1.0.0 h1:L2M1tAxyYxmd75PrWwlZpgwPxuGe1HteSsVuoLXcUuI=
-github.com/klmitch/patcher v1.0.0/go.mod h1:LkqbKUzmnDlGe+ge1lMIlBR6D0fHPNCxuPw8NnQzH50=
 github.com/klmitch/patcher v1.0.1 h1:251Y+/b0PA4GVicoo+RV0ay2wHnDbm6GOEUhzYOhGFc=
 github.com/klmitch/patcher v1.0.1/go.mod h1:LkqbKUzmnDlGe+ge1lMIlBR6D0fHPNCxuPw8NnQzH50=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
@@ -54,6 +54,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -67,7 +68,9 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20200219222553-88b1720de6a2 h1:sDCXP/SL7PwRgUEwAJ8Sfeu0JUXeMEIyxMCtJuRANDE=
 golang.org/x/tools v0.0.0-20200219222553-88b1720de6a2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/scripts/overcover.mk
+++ b/scripts/overcover.mk
@@ -1,0 +1,19 @@
+## Copyright (c) 2020 Kevin L. Mitchell
+##
+## Licensed under the Apache License, Version 2.0 (the "License"); you
+## may not use this file except in compliance with the License.  You
+## may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied.  See the License for the specific language governing
+## permissions and limitations under the License.
+
+# Override the OVERCOVER value to use the local OVERCOVER
+OVERCOVER = ./overcover
+
+# Ensure that cover-test depends on OVERCOVER
+cover-test: $(OVERCOVER)


### PR DESCRIPTION
This PR contains several updates to the Makefile.  This includes adding a "tidy" target to run "go mod tidy"; setting up an appropriate cover-test target that will work for all go projects; reworking the code that constructs the targets for building binaries; adding code that keeps .gitignore synchronized; and adding a "help" target.  This commit also contains an update to .travis.yml and a scripts/overcover.mk which tailors this Makefile for the overcover repository.