### PR TITLE
Add tool installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ overcover
 coverage.out
 coverage.html
 .gitignore.tmp
+tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,5 @@ language: go
 go:
 - "1.13.x"
 - "1.14.x"
-install:
-- MOD=`grep '^module ' go.mod | awk '{print $NF}'`
-- DIR=`pwd`
-- mkdir tools
-- cd tools
-- go mod init ${MOD}/tools
-- go install golang.org/x/tools/cmd/goimports
-- go install golang.org/x/lint/golint
-- go install github.com/mattn/goveralls
-- cd ${DIR}
 script:
-- make CI=true
-- $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci
+- make all goveralls CI=true

--- a/scripts/overcover.mk
+++ b/scripts/overcover.mk
@@ -14,6 +14,3 @@
 
 # Override the OVERCOVER value to use the local OVERCOVER
 OVERCOVER = ./overcover
-
-# Ensure that cover-test depends on OVERCOVER
-cover-test: $(OVERCOVER)


### PR DESCRIPTION
This MR adds code to the Makefile to on-demand install the tools that are required for the make operation.  The tools are installed into a new tools directory with its own go.mod to avoid dirtying up the package's go.mod.  A new (explicitly undocumented) goveralls target is also added, to leverage this tooling for goveralls in the Travis run.  The .travis.yml is also updated to leverage the new tooling; no install section is needed anymore.